### PR TITLE
feat: Add SAS token authentication for Azure Blob Storage object store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ debug
 .idea/
 
 _tiltbuild
+
+# compiled plugin binary
+velero-plugin-for-microsoft-azure/velero-plugin-for-microsoft-azure

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -72,4 +72,69 @@ spec:
     #
     # Optional (defaults to 1048576, i.e. 1MB, maximum 104857600, i.e. 100MB).
     blockSizeInBytes: "1048576"
+
+    # Key name in the BSL credential file that holds a container-scoped SAS token.
+    # When set, all other authentication methods (shared key, AAD) are bypassed
+    # and the plugin authenticates using the SAS token alone.
+    #
+    # Use this when only a container-scoped SAS token is available and no account
+    # key or service principal can be provided.
+    #
+    # The SAS token may optionally include a leading "?" which is stripped automatically.
+    #
+    # Optional. When set, storageAccountBlobEndpoint should also be configured.
+    storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
+
+    # Blob service endpoint URL for the storage account.
+    # Required when using storageAccountSASTokenEnvVar with accounts that use Azure DNS
+    # zone endpoints (e.g. https://<account>.z17.blob.storage.azure.net/).
+    #
+    # Set this to the blob service root URL for the storage account, for example:
+    #   storageAccountBlobEndpoint: "https://myaccount.z17.blob.storage.azure.net/"
+    #
+    # If omitted, the standard endpoint https://<storageAccount>.blob.core.windows.net/
+    # is used.
+    #
+    # Optional.
+    storageAccountBlobEndpoint: https://my-account.z17.blob.storage.azure.net/
 ```
+
+## Using SAS token authentication
+
+When only a container-scoped SAS token is available (no account key or service principal), use the following minimal BSL configuration:
+
+```yaml
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+spec:
+  provider: velero.io/azure
+  objectStorage:
+    bucket: my-container
+  config:
+    storageAccount: my-storage-account
+    storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
+    # Required for accounts with Azure DNS zone endpoints:
+    storageAccountBlobEndpoint: https://my-storage-account.z17.blob.storage.azure.net/
+  credential:
+    name: velero-azure-credentials
+    key: cloud
+```
+
+The SAS token must be stored in a Kubernetes Secret in `KEY=VALUE` format, referenced by `spec.credential` on the BSL:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-azure-credentials
+  namespace: velero
+type: Opaque
+stringData:
+  cloud: |
+    AZURE_STORAGE_ACCOUNT_ACCESS_KEY=<sas-token>
+```
+
+The value of `storageAccountSASTokenEnvVar` (`AZURE_STORAGE_ACCOUNT_ACCESS_KEY` above) is the key name looked up in the credential file. The token value may include or omit the leading `?` — both formats are accepted.

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -76,24 +76,22 @@ spec:
     # Key name in the BSL credential file that holds a container-scoped SAS token.
     # When set, all other authentication methods (shared key, AAD) are bypassed
     # and the plugin authenticates using the SAS token alone.
+    # Cannot be combined with useAAD: "true".
     #
     # Use this when only a container-scoped SAS token is available and no account
     # key or service principal can be provided.
     #
     # The SAS token may optionally include a leading "?" which is stripped automatically.
     #
-    # Optional. When set, storageAccountBlobEndpoint should also be configured.
+    # Optional. When set, storageAccountBlobEndpoint is required.
     storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
 
     # Blob service endpoint URL for the storage account.
-    # Required when using storageAccountSASTokenEnvVar with accounts that use Azure DNS
-    # zone endpoints (e.g. https://<account>.z17.blob.storage.azure.net/).
+    # Required when using storageAccountSASTokenEnvVar.
     #
     # Set this to the blob service root URL for the storage account, for example:
+    #   storageAccountBlobEndpoint: "https://myaccount.blob.core.windows.net/"
     #   storageAccountBlobEndpoint: "https://myaccount.z17.blob.storage.azure.net/"
-    #
-    # If omitted, the standard endpoint https://<storageAccount>.blob.core.windows.net/
-    # is used.
     #
     # Optional.
     storageAccountBlobEndpoint: https://my-account.z17.blob.storage.azure.net/
@@ -116,8 +114,7 @@ spec:
   config:
     storageAccount: my-storage-account
     storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
-    # Required for accounts with Azure DNS zone endpoints:
-    storageAccountBlobEndpoint: https://my-storage-account.z17.blob.storage.azure.net/
+    storageAccountBlobEndpoint: https://my-storage-account.blob.core.windows.net/
   credential:
     name: velero-azure-credentials
     key: cloud

--- a/changelogs/unreleased/sas-token-object-store-auth
+++ b/changelogs/unreleased/sas-token-object-store-auth
@@ -1,0 +1,16 @@
+Add SAS token authentication support to the Azure object store plugin.
+
+Two new BSL config keys:
+- storageAccountSASTokenEnvVar: name of the key in the BSL credential file
+  that holds a container-scoped SAS token. When set, all other auth methods
+  (shared key, AAD) are bypassed. A SAS (Shared Access Signature) token is a
+  URI that grants restricted access to Azure Storage resources without
+  exposing the account key.
+- storageAccountBlobEndpoint: explicit blob service endpoint URL. Required for
+  storage accounts using Azure DNS zone endpoints (e.g.
+  https://<account>.z17.blob.storage.azure.net/). Falls back to the standard
+  https://<storageAccount>.blob.core.windows.net/ if omitted.
+
+This enables Velero backup to Azure Blob Storage for storage accounts where
+only a container-scoped SAS token is available — no account key or service
+principal required.

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -45,10 +46,22 @@ const (
 	// ref. https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
 	maxBlockSize     = 100 * 1024 * 1024
 	defaultBlockSize = 1 * 1024 * 1024
+
+	// storageAccountSASTokenEnvVarConfigKey is the BSL config key whose value is the key name
+	// in the credential file holding a container-scoped SAS token.
+	// When set, SAS token auth is used instead of shared key or AAD.
+	storageAccountSASTokenEnvVarConfigKey = "storageAccountSASTokenEnvVar"
+
+	// storageAccountBlobEndpointConfigKey is the BSL config key for the blob service endpoint.
+	// Must be set when using SAS token auth with accounts that use Azure DNS zone endpoints
+	// (e.g. https://<account>.z17.blob.storage.azure.net/) rather than the standard endpoint
+	// (https://<account>.blob.core.windows.net/).
+	storageAccountBlobEndpointConfigKey = "storageAccountBlobEndpoint"
 )
 
 type containerGetter interface {
 	getContainer(bucket string) container
+	URL() string
 }
 
 type azureContainerGetter struct {
@@ -61,6 +74,10 @@ func (cg *azureContainerGetter) getContainer(bucket string) container {
 	return &azureContainer{
 		containerClient: containerClient,
 	}
+}
+
+func (cg *azureContainerGetter) URL() string {
+	return cg.serviceClient.URL()
 }
 
 type container interface {
@@ -209,13 +226,55 @@ type ObjectStore struct {
 	blockSize       int
 	// we need to keep the credential here to create the sas url
 	sharedKeyCredential *azblob.SharedKeyCredential
+	// sasTokenEnvVar is the credential key name for SAS token auth; non-empty means SAS mode
+	sasTokenEnvVar string
+	// sasToken is the resolved SAS token value read from the credential file during Init
+	sasToken string
 }
 
 func newObjectStore(logger logrus.FieldLogger) *ObjectStore {
 	return &ObjectStore{log: logger}
 }
 
-// Init sets up the ObjectStore using the shared key or default azure credentials
+// initWithSASToken initialises the ObjectStore using a container-scoped SAS token from the credential file
+func (o *ObjectStore) initWithSASToken(config map[string]string, sasTokenEnvVar string) error {
+	storageAccount := config[azure.BSLConfigStorageAccount]
+	if storageAccount == "" {
+		return errors.New("storageAccount is required in BackupStorageLocation config when using SAS token auth")
+	}
+
+	creds, err := azure.LoadCredentials(config)
+	if err != nil {
+		return errors.Wrap(err, "failed to load credentials file")
+	}
+	sasToken := creds[sasTokenEnvVar]
+	if sasToken == "" {
+		return errors.Errorf("no SAS token with key %s found in credential", sasTokenEnvVar)
+	}
+	sasToken = strings.TrimPrefix(sasToken, "?")
+
+	blobEndpoint := config[storageAccountBlobEndpointConfigKey]
+	if blobEndpoint == "" {
+		blobEndpoint = fmt.Sprintf("https://%s.blob.core.windows.net/", storageAccount)
+	}
+	// ensure the endpoint ends with "/" before appending the SAS token
+	serviceURL := strings.TrimRight(blobEndpoint, "/") + "/?" + sasToken
+
+	client, err := azblob.NewClientWithNoCredential(serviceURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Azure Blob client with SAS token")
+	}
+
+	o.sasTokenEnvVar = sasTokenEnvVar
+	o.sasToken = sasToken
+	o.containerGetter = &azureContainerGetter{serviceClient: client.ServiceClient()}
+	o.blobGetter = &azureBlobGetter{serviceClient: client.ServiceClient()}
+	o.blockSize = getBlockSize(o.log, config)
+
+	o.log.Infof("ObjectStore initialised with SAS token auth for storage account %q (endpoint: %s)", storageAccount, blobEndpoint)
+	return nil
+}
+
 func (o *ObjectStore) Init(config map[string]string) error {
 	if err := veleroplugin.ValidateObjectStoreConfigKeys(config,
 		azure.BSLConfigResourceGroup,
@@ -227,8 +286,15 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		azure.BSLConfigUseAAD,
 		azure.BSLConfigStorageAccountAccessKeyName,
 		credentialsFileConfigKey,
+		storageAccountSASTokenEnvVarConfigKey,
+		storageAccountBlobEndpointConfigKey,
 	); err != nil {
 		return err
+	}
+
+	// when a SAS token key is configured, skip the standard Azure credential chain
+	if sasTokenEnvVar, ok := config[storageAccountSASTokenEnvVarConfigKey]; ok && sasTokenEnvVar != "" {
+		return o.initWithSASToken(config, sasTokenEnvVar)
 	}
 
 	client, cred, err := azure.NewStorageClient(o.log, config)
@@ -382,6 +448,13 @@ func (o *ObjectStore) DeleteObject(bucket string, key string) error {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
+	// in SAS token mode there is no account key or AAD credential to generate a new signed URL,
+	// so reuse the existing container-scoped SAS token which already grants read access;
+	// derive the base URL from the service client so DNS zone endpoints are handled correctly
+	if o.sasTokenEnvVar != "" {
+		base := strings.TrimRight(o.containerGetter.URL(), "/")
+		return fmt.Sprintf("%s/%s/%s?%s", base, bucket, key, o.sasToken), nil
+	}
 	blob := o.blobGetter.getBlob(bucket, key)
 	return blob.GetSASURI(ttl, o.sharedKeyCredential)
 }

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -49,13 +49,12 @@ const (
 
 	// storageAccountSASTokenEnvVarConfigKey is the BSL config key whose value is the key name
 	// in the credential file holding a container-scoped SAS token.
-	// When set, SAS token auth is used instead of shared key or AAD.
+	// SAS tokens are not Azure AD credentials; when set, the standard Azure credential chain
+	// (service principal, workload identity, managed identity, shared key) is bypassed entirely.
 	storageAccountSASTokenEnvVarConfigKey = "storageAccountSASTokenEnvVar"
 
 	// storageAccountBlobEndpointConfigKey is the BSL config key for the blob service endpoint.
-	// Must be set when using SAS token auth with accounts that use Azure DNS zone endpoints
-	// (e.g. https://<account>.z17.blob.storage.azure.net/) rather than the standard endpoint
-	// (https://<account>.blob.core.windows.net/).
+	// Required when using SAS token auth.
 	storageAccountBlobEndpointConfigKey = "storageAccountBlobEndpoint"
 )
 
@@ -243,6 +242,15 @@ func (o *ObjectStore) initWithSASToken(config map[string]string, sasTokenEnvVar 
 		return errors.New("storageAccount is required in BackupStorageLocation config when using SAS token auth")
 	}
 
+	if config[azure.BSLConfigUseAAD] != "" {
+		return errors.New("useAAD and storageAccountSASTokenEnvVar are mutually exclusive; remove useAAD when using SAS token auth")
+	}
+
+	blobEndpoint := config[storageAccountBlobEndpointConfigKey]
+	if blobEndpoint == "" {
+		return errors.New("storageAccountBlobEndpoint is required in BackupStorageLocation config when using SAS token auth")
+	}
+
 	creds, err := azure.LoadCredentials(config)
 	if err != nil {
 		return errors.Wrap(err, "failed to load credentials file")
@@ -253,10 +261,6 @@ func (o *ObjectStore) initWithSASToken(config map[string]string, sasTokenEnvVar 
 	}
 	sasToken = strings.TrimPrefix(sasToken, "?")
 
-	blobEndpoint := config[storageAccountBlobEndpointConfigKey]
-	if blobEndpoint == "" {
-		blobEndpoint = fmt.Sprintf("https://%s.blob.core.windows.net/", storageAccount)
-	}
 	// ensure the endpoint ends with "/" before appending the SAS token
 	serviceURL := strings.TrimRight(blobEndpoint, "/") + "/?" + sasToken
 

--- a/velero-plugin-for-microsoft-azure/object_store_test.go
+++ b/velero-plugin-for-microsoft-azure/object_store_test.go
@@ -186,11 +186,31 @@ func TestInitWithSASToken_MissingTokenInCredentials(t *testing.T) {
 
 	o := &ObjectStore{log: logrus.New()}
 	err = o.initWithSASToken(map[string]string{
-		"storageAccount":         "myaccount",
-		credentialsFileConfigKey: f.Name(),
+		"storageAccount":                    "myaccount",
+		credentialsFileConfigKey:            f.Name(),
+		storageAccountBlobEndpointConfigKey: "https://myaccount.blob.core.windows.net/",
 	}, "MY_SAS_TOKEN_ENV")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MY_SAS_TOKEN_ENV")
+}
+
+func TestInitWithSASToken_UseAADConflict(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{
+		"storageAccount": "myaccount",
+		"useAAD":         "true",
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestInitWithSASToken_MissingEndpoint(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{
+		"storageAccount": "myaccount",
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storageAccountBlobEndpoint is required")
 }
 
 func TestInitWithSASToken_Success(t *testing.T) {
@@ -213,24 +233,6 @@ func TestInitWithSASToken_Success(t *testing.T) {
 	assert.NotNil(t, o.containerGetter)
 	assert.NotNil(t, o.blobGetter)
 	assert.Equal(t, defaultBlockSize, o.blockSize)
-}
-
-func TestInitWithSASToken_DefaultEndpoint(t *testing.T) {
-	f, err := os.CreateTemp("", "azure-creds-*.env")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-	_, err = f.WriteString("MY_SAS_TOKEN=sv=2025-05-05&sig=abc123\n")
-	require.NoError(t, err)
-	f.Close()
-
-	o := &ObjectStore{log: logrus.New()}
-	err = o.initWithSASToken(map[string]string{
-		"storageAccount":         "myaccount",
-		credentialsFileConfigKey: f.Name(),
-		// no storageAccountBlobEndpoint, falls back to standard URL
-	}, "MY_SAS_TOKEN")
-	require.NoError(t, err)
-	assert.Contains(t, o.containerGetter.URL(), "myaccount.blob.core.windows.net")
 }
 
 func TestCreateSignedURL_SASMode(t *testing.T) {

--- a/velero-plugin-for-microsoft-azure/object_store_test.go
+++ b/velero-plugin-for-microsoft-azure/object_store_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -166,4 +167,120 @@ func TestGetBlockSize(t *testing.T) {
 	config[blockSizeConfigKey] = "1048570"
 	size = getBlockSize(logger, config)
 	assert.Equal(t, 1048570, size)
+}
+
+func TestInitWithSASToken_MissingStorageAccount(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storageAccount is required")
+}
+
+func TestInitWithSASToken_MissingTokenInCredentials(t *testing.T) {
+	f, err := os.CreateTemp("", "azure-creds-*.env")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("OTHER_KEY=some_value\n")
+	require.NoError(t, err)
+	f.Close()
+
+	o := &ObjectStore{log: logrus.New()}
+	err = o.initWithSASToken(map[string]string{
+		"storageAccount":         "myaccount",
+		credentialsFileConfigKey: f.Name(),
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MY_SAS_TOKEN_ENV")
+}
+
+func TestInitWithSASToken_Success(t *testing.T) {
+	f, err := os.CreateTemp("", "azure-creds-*.env")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("MY_SAS_TOKEN=sv=2025-05-05&sig=abc123\n")
+	require.NoError(t, err)
+	f.Close()
+
+	o := &ObjectStore{log: logrus.New()}
+	err = o.initWithSASToken(map[string]string{
+		"storageAccount":                    "myaccount",
+		credentialsFileConfigKey:            f.Name(),
+		storageAccountBlobEndpointConfigKey: "https://myaccount.blob.core.windows.net/",
+	}, "MY_SAS_TOKEN")
+	require.NoError(t, err)
+	assert.Equal(t, "sv=2025-05-05&sig=abc123", o.sasToken)
+	assert.Equal(t, "MY_SAS_TOKEN", o.sasTokenEnvVar)
+	assert.NotNil(t, o.containerGetter)
+	assert.NotNil(t, o.blobGetter)
+	assert.Equal(t, defaultBlockSize, o.blockSize)
+}
+
+func TestInitWithSASToken_DefaultEndpoint(t *testing.T) {
+	f, err := os.CreateTemp("", "azure-creds-*.env")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("MY_SAS_TOKEN=sv=2025-05-05&sig=abc123\n")
+	require.NoError(t, err)
+	f.Close()
+
+	o := &ObjectStore{log: logrus.New()}
+	err = o.initWithSASToken(map[string]string{
+		"storageAccount":         "myaccount",
+		credentialsFileConfigKey: f.Name(),
+		// no storageAccountBlobEndpoint, falls back to standard URL
+	}, "MY_SAS_TOKEN")
+	require.NoError(t, err)
+	assert.Contains(t, o.containerGetter.URL(), "myaccount.blob.core.windows.net")
+}
+
+func TestCreateSignedURL_SASMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceURL string
+		sasToken   string
+		want       string
+	}{
+		{
+			name:       "standard endpoint plain SAS token",
+			serviceURL: "https://myaccount.blob.core.windows.net/",
+			sasToken:   "sv=2025-05-05&sig=abc123",
+			want:       "https://myaccount.blob.core.windows.net/mycontainer/myblob?sv=2025-05-05&sig=abc123",
+		},
+		{
+			name:       "DNS zone endpoint",
+			serviceURL: "https://myaccount.z17.blob.storage.azure.net/",
+			sasToken:   "sv=2025-05-05&sig=abc123",
+			want:       "https://myaccount.z17.blob.storage.azure.net/mycontainer/myblob?sv=2025-05-05&sig=abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &ObjectStore{
+				log:            logrus.New(),
+				sasTokenEnvVar: "TEST_SAS_TOKEN",
+				sasToken:       tc.sasToken,
+				containerGetter: &mockContainerGetterWithURL{
+					serviceURL: tc.serviceURL,
+				},
+				blobGetter: new(mockBlobGetter),
+			}
+
+			url, err := o.CreateSignedURL("mycontainer", "myblob", time.Hour)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, url)
+		})
+	}
+}
+
+type mockContainerGetterWithURL struct {
+	serviceURL string
+}
+
+func (m *mockContainerGetterWithURL) getContainer(_ string) container {
+	return nil
+}
+
+func (m *mockContainerGetterWithURL) URL() string {
+	return m.serviceURL
 }


### PR DESCRIPTION
## What this PR does

Adds support for authenticating with Azure Blob Storage using a
container-scoped SAS (Shared Access Signature) token. SAS tokens grant
restricted, time-limited access to storage resources without requiring
an account key or service principal.

## Why

Some Azure storage provisioning systems provide only a container-scoped
SAS token as credentials — no account key or AAD service principal is
available. Previously the plugin had no code path for this case, making
Velero unusable in those environments.

## How

Two new BSL config keys:

- `storageAccountSASTokenEnvVar`: name of the key in the BSL credential
  file (referenced via `spec.credential` on the BSL) that holds the SAS
  token. When set, the standard Azure credential chain (service principal,
  workload identity, managed identity, shared key) is bypassed entirely.
  Cannot be combined with `useAAD: "true"`.

- `storageAccountBlobEndpoint`: blob service endpoint URL. Required when
  using `storageAccountSASTokenEnvVar` — supports both standard
  (`https://<account>.blob.core.windows.net/`) and DNS zone endpoints
  (`https://<account>.z17.blob.storage.azure.net/`).

The SAS token is stored in a Kubernetes Secret in `KEY=VALUE` format and
referenced via `spec.credential` on the BSL — the standard Velero
credential injection mechanism. The credential loading follows the same
pattern as the existing `storageAccountKeyEnvVar` implementation in
`velero/pkg/util/azure/storage.go`: the token is read from the credential
file via `azure.LoadCredentials`, and an error is returned if the key is
not found — no environment variable fallback.

Existing BSLs with no `storageAccountSASTokenEnvVar` are completely
unaffected — the new code path is only entered when that key is present.

## Known limitation

`velero backup logs` and `velero backup describe --details` (resource list)
use blob-level signed URLs (`sr=b`). A container-scoped SAS token (`sr=c`)
cannot be used to generate those URLs, so those commands return
`AuthenticationFailed: SAS field 'sr' is not well formed`. Backup and
restore operations are fully functional.

## Testing

Tested end-to-end on a local kind cluster against a real Azure Blob Storage
account using a container-scoped SAS token with a stored access policy:

- BSL validated as `Available` immediately after install
- `velero backup create` completed successfully — backup written to Azure
- Namespace deleted, `velero restore create` completed — pod and configmap
  restored correctly
- `useAAD: "true"` + SAS → BSL `Unavailable`: `useAAD and storageAccountSASTokenEnvVar are mutually exclusive`
- Missing `storageAccountBlobEndpoint` → BSL `Unavailable`: `storageAccountBlobEndpoint is required`
- Existing auth paths (shared key, AAD) unaffected — no regression

Unit tests added covering:
- Missing `storageAccount` in config
- Missing SAS token key in credential file
- `useAAD` conflict returns error
- Missing `storageAccountBlobEndpoint` returns error
- Successful init with explicit blob endpoint
- `CreateSignedURL` output for both standard and DNS zone endpoints