### PR TITLE
[release-1.13] feat: Add SAS token authentication for Azure Blob Storage object store (cherry-pick #314)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ debug
 .idea/
 
 _tiltbuild
+
+# compiled plugin binary
+velero-plugin-for-microsoft-azure/velero-plugin-for-microsoft-azure

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -72,4 +72,66 @@ spec:
     #
     # Optional (defaults to 1048576, i.e. 1MB, maximum 104857600, i.e. 100MB).
     blockSizeInBytes: "1048576"
+
+    # Key name in the BSL credential file that holds a container-scoped SAS token.
+    # When set, all other authentication methods (shared key, AAD) are bypassed
+    # and the plugin authenticates using the SAS token alone.
+    # Cannot be combined with useAAD: "true".
+    #
+    # Use this when only a container-scoped SAS token is available and no account
+    # key or service principal can be provided.
+    #
+    # The SAS token may optionally include a leading "?" which is stripped automatically.
+    #
+    # Optional. When set, storageAccountBlobEndpoint is required.
+    storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
+
+    # Blob service endpoint URL for the storage account.
+    # Required when using storageAccountSASTokenEnvVar.
+    #
+    # Set this to the blob service root URL for the storage account, for example:
+    #   storageAccountBlobEndpoint: "https://myaccount.blob.core.windows.net/"
+    #   storageAccountBlobEndpoint: "https://myaccount.z17.blob.storage.azure.net/"
+    #
+    # Optional.
+    storageAccountBlobEndpoint: https://my-account.z17.blob.storage.azure.net/
 ```
+
+## Using SAS token authentication
+
+When only a container-scoped SAS token is available (no account key or service principal), use the following minimal BSL configuration:
+
+```yaml
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+spec:
+  provider: velero.io/azure
+  objectStorage:
+    bucket: my-container
+  config:
+    storageAccount: my-storage-account
+    storageAccountSASTokenEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
+    storageAccountBlobEndpoint: https://my-storage-account.blob.core.windows.net/
+  credential:
+    name: velero-azure-credentials
+    key: cloud
+```
+
+The SAS token must be stored in a Kubernetes Secret in `KEY=VALUE` format, referenced by `spec.credential` on the BSL:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-azure-credentials
+  namespace: velero
+type: Opaque
+stringData:
+  cloud: |
+    AZURE_STORAGE_ACCOUNT_ACCESS_KEY=<sas-token>
+```
+
+The value of `storageAccountSASTokenEnvVar` (`AZURE_STORAGE_ACCOUNT_ACCESS_KEY` above) is the key name looked up in the credential file. The token value may include or omit the leading `?` — both formats are accepted.

--- a/changelogs/unreleased/sas-token-object-store-auth
+++ b/changelogs/unreleased/sas-token-object-store-auth
@@ -1,0 +1,16 @@
+Add SAS token authentication support to the Azure object store plugin.
+
+Two new BSL config keys:
+- storageAccountSASTokenEnvVar: name of the key in the BSL credential file
+  that holds a container-scoped SAS token. When set, all other auth methods
+  (shared key, AAD) are bypassed. A SAS (Shared Access Signature) token is a
+  URI that grants restricted access to Azure Storage resources without
+  exposing the account key.
+- storageAccountBlobEndpoint: explicit blob service endpoint URL. Required for
+  storage accounts using Azure DNS zone endpoints (e.g.
+  https://<account>.z17.blob.storage.azure.net/). Falls back to the standard
+  https://<storageAccount>.blob.core.windows.net/ if omitted.
+
+This enables Velero backup to Azure Blob Storage for storage accounts where
+only a container-scoped SAS token is available — no account key or service
+principal required.

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -45,10 +46,21 @@ const (
 	// ref. https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
 	maxBlockSize     = 100 * 1024 * 1024
 	defaultBlockSize = 1 * 1024 * 1024
+
+	// storageAccountSASTokenEnvVarConfigKey is the BSL config key whose value is the key name
+	// in the credential file holding a container-scoped SAS token.
+	// SAS tokens are not Azure AD credentials; when set, the standard Azure credential chain
+	// (service principal, workload identity, managed identity, shared key) is bypassed entirely.
+	storageAccountSASTokenEnvVarConfigKey = "storageAccountSASTokenEnvVar"
+
+	// storageAccountBlobEndpointConfigKey is the BSL config key for the blob service endpoint.
+	// Required when using SAS token auth.
+	storageAccountBlobEndpointConfigKey = "storageAccountBlobEndpoint"
 )
 
 type containerGetter interface {
 	getContainer(bucket string) container
+	URL() string
 }
 
 type azureContainerGetter struct {
@@ -61,6 +73,10 @@ func (cg *azureContainerGetter) getContainer(bucket string) container {
 	return &azureContainer{
 		containerClient: containerClient,
 	}
+}
+
+func (cg *azureContainerGetter) URL() string {
+	return cg.serviceClient.URL()
 }
 
 type container interface {
@@ -209,13 +225,60 @@ type ObjectStore struct {
 	blockSize       int
 	// we need to keep the credential here to create the sas url
 	sharedKeyCredential *azblob.SharedKeyCredential
+	// sasTokenEnvVar is the credential key name for SAS token auth; non-empty means SAS mode
+	sasTokenEnvVar string
+	// sasToken is the resolved SAS token value read from the credential file during Init
+	sasToken string
 }
 
 func newObjectStore(logger logrus.FieldLogger) *ObjectStore {
 	return &ObjectStore{log: logger}
 }
 
-// Init sets up the ObjectStore using the shared key or default azure credentials
+// initWithSASToken initialises the ObjectStore using a container-scoped SAS token from the credential file
+func (o *ObjectStore) initWithSASToken(config map[string]string, sasTokenEnvVar string) error {
+	storageAccount := config[azure.BSLConfigStorageAccount]
+	if storageAccount == "" {
+		return errors.New("storageAccount is required in BackupStorageLocation config when using SAS token auth")
+	}
+
+	if config[azure.BSLConfigUseAAD] != "" {
+		return errors.New("useAAD and storageAccountSASTokenEnvVar are mutually exclusive; remove useAAD when using SAS token auth")
+	}
+
+	blobEndpoint := config[storageAccountBlobEndpointConfigKey]
+	if blobEndpoint == "" {
+		return errors.New("storageAccountBlobEndpoint is required in BackupStorageLocation config when using SAS token auth")
+	}
+
+	creds, err := azure.LoadCredentials(config)
+	if err != nil {
+		return errors.Wrap(err, "failed to load credentials file")
+	}
+	sasToken := creds[sasTokenEnvVar]
+	if sasToken == "" {
+		return errors.Errorf("no SAS token with key %s found in credential", sasTokenEnvVar)
+	}
+	sasToken = strings.TrimPrefix(sasToken, "?")
+
+	// ensure the endpoint ends with "/" before appending the SAS token
+	serviceURL := strings.TrimRight(blobEndpoint, "/") + "/?" + sasToken
+
+	client, err := azblob.NewClientWithNoCredential(serviceURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Azure Blob client with SAS token")
+	}
+
+	o.sasTokenEnvVar = sasTokenEnvVar
+	o.sasToken = sasToken
+	o.containerGetter = &azureContainerGetter{serviceClient: client.ServiceClient()}
+	o.blobGetter = &azureBlobGetter{serviceClient: client.ServiceClient()}
+	o.blockSize = getBlockSize(o.log, config)
+
+	o.log.Infof("ObjectStore initialised with SAS token auth for storage account %q (endpoint: %s)", storageAccount, blobEndpoint)
+	return nil
+}
+
 func (o *ObjectStore) Init(config map[string]string) error {
 	if err := veleroplugin.ValidateObjectStoreConfigKeys(config,
 		azure.BSLConfigResourceGroup,
@@ -227,8 +290,15 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		azure.BSLConfigUseAAD,
 		azure.BSLConfigStorageAccountAccessKeyName,
 		credentialsFileConfigKey,
+		storageAccountSASTokenEnvVarConfigKey,
+		storageAccountBlobEndpointConfigKey,
 	); err != nil {
 		return err
+	}
+
+	// when a SAS token key is configured, skip the standard Azure credential chain
+	if sasTokenEnvVar, ok := config[storageAccountSASTokenEnvVarConfigKey]; ok && sasTokenEnvVar != "" {
+		return o.initWithSASToken(config, sasTokenEnvVar)
 	}
 
 	client, cred, err := azure.NewStorageClient(o.log, config)
@@ -382,6 +452,13 @@ func (o *ObjectStore) DeleteObject(bucket string, key string) error {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
+	// in SAS token mode there is no account key or AAD credential to generate a new signed URL,
+	// so reuse the existing container-scoped SAS token which already grants read access;
+	// derive the base URL from the service client so DNS zone endpoints are handled correctly
+	if o.sasTokenEnvVar != "" {
+		base := strings.TrimRight(o.containerGetter.URL(), "/")
+		return fmt.Sprintf("%s/%s/%s?%s", base, bucket, key, o.sasToken), nil
+	}
 	blob := o.blobGetter.getBlob(bucket, key)
 	return blob.GetSASURI(ttl, o.sharedKeyCredential)
 }

--- a/velero-plugin-for-microsoft-azure/object_store_test.go
+++ b/velero-plugin-for-microsoft-azure/object_store_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -166,4 +167,122 @@ func TestGetBlockSize(t *testing.T) {
 	config[blockSizeConfigKey] = "1048570"
 	size = getBlockSize(logger, config)
 	assert.Equal(t, 1048570, size)
+}
+
+func TestInitWithSASToken_MissingStorageAccount(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storageAccount is required")
+}
+
+func TestInitWithSASToken_MissingTokenInCredentials(t *testing.T) {
+	f, err := os.CreateTemp("", "azure-creds-*.env")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("OTHER_KEY=some_value\n")
+	require.NoError(t, err)
+	f.Close()
+
+	o := &ObjectStore{log: logrus.New()}
+	err = o.initWithSASToken(map[string]string{
+		"storageAccount":                    "myaccount",
+		credentialsFileConfigKey:            f.Name(),
+		storageAccountBlobEndpointConfigKey: "https://myaccount.blob.core.windows.net/",
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MY_SAS_TOKEN_ENV")
+}
+
+func TestInitWithSASToken_UseAADConflict(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{
+		"storageAccount": "myaccount",
+		"useAAD":         "true",
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestInitWithSASToken_MissingEndpoint(t *testing.T) {
+	o := &ObjectStore{log: logrus.New()}
+	err := o.initWithSASToken(map[string]string{
+		"storageAccount": "myaccount",
+	}, "MY_SAS_TOKEN_ENV")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storageAccountBlobEndpoint is required")
+}
+
+func TestInitWithSASToken_Success(t *testing.T) {
+	f, err := os.CreateTemp("", "azure-creds-*.env")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("MY_SAS_TOKEN=sv=2025-05-05&sig=abc123\n")
+	require.NoError(t, err)
+	f.Close()
+
+	o := &ObjectStore{log: logrus.New()}
+	err = o.initWithSASToken(map[string]string{
+		"storageAccount":                    "myaccount",
+		credentialsFileConfigKey:            f.Name(),
+		storageAccountBlobEndpointConfigKey: "https://myaccount.blob.core.windows.net/",
+	}, "MY_SAS_TOKEN")
+	require.NoError(t, err)
+	assert.Equal(t, "sv=2025-05-05&sig=abc123", o.sasToken)
+	assert.Equal(t, "MY_SAS_TOKEN", o.sasTokenEnvVar)
+	assert.NotNil(t, o.containerGetter)
+	assert.NotNil(t, o.blobGetter)
+	assert.Equal(t, defaultBlockSize, o.blockSize)
+}
+
+func TestCreateSignedURL_SASMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceURL string
+		sasToken   string
+		want       string
+	}{
+		{
+			name:       "standard endpoint plain SAS token",
+			serviceURL: "https://myaccount.blob.core.windows.net/",
+			sasToken:   "sv=2025-05-05&sig=abc123",
+			want:       "https://myaccount.blob.core.windows.net/mycontainer/myblob?sv=2025-05-05&sig=abc123",
+		},
+		{
+			name:       "DNS zone endpoint",
+			serviceURL: "https://myaccount.z17.blob.storage.azure.net/",
+			sasToken:   "sv=2025-05-05&sig=abc123",
+			want:       "https://myaccount.z17.blob.storage.azure.net/mycontainer/myblob?sv=2025-05-05&sig=abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &ObjectStore{
+				log:            logrus.New(),
+				sasTokenEnvVar: "TEST_SAS_TOKEN",
+				sasToken:       tc.sasToken,
+				containerGetter: &mockContainerGetterWithURL{
+					serviceURL: tc.serviceURL,
+				},
+				blobGetter: new(mockBlobGetter),
+			}
+
+			url, err := o.CreateSignedURL("mycontainer", "myblob", time.Hour)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, url)
+		})
+	}
+}
+
+type mockContainerGetterWithURL struct {
+	serviceURL string
+}
+
+func (m *mockContainerGetterWithURL) getContainer(_ string) container {
+	return nil
+}
+
+func (m *mockContainerGetterWithURL) URL() string {
+	return m.serviceURL
 }


### PR DESCRIPTION
Cherry-pick of #314 to `release-1.13`.

Original PR: https://github.com/velero-io/velero-plugin-for-microsoft-azure/pull/314

> [!Note]
> Responses generated with Claude
